### PR TITLE
UltraMC, hide sneaking & invisible (potion) players.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,4 +2,9 @@ updateInterval: 5000
 targetFile: /path/to/overviewermap/markers.json
 saveOfflinePlayers: true
 hideVanishedPlayers: true
+hideSneakingPlayers: true
+hideInvisiblePlayers: true
+sendJSONOnVanishedPlayers: false
+sendJSONOnSneakingPlayers: false
+sendJSONOnInvisiblePlayers: false
 offlineFile: locations.bin


### PR DESCRIPTION
Configurable option is:
if player is invisible and his head will be not dislpayed (for
Overviewer map id 4 for example) we can decide to include that player in
JSON with "invisible ID" or not even send data of that player at all.
